### PR TITLE
disable draggable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Feature
 
+- disable dragging for desktop devices to prevent link activation on drag @ThomasKindermann
+
 ### Bugfix
 
 ### Internal

--- a/src/components/View.jsx
+++ b/src/components/View.jsx
@@ -78,6 +78,7 @@ const SliderView = (props) => {
           speed={500}
           slidesToShow={1}
           slidesToScroll={1}
+          draggable={false}
           nextArrow={<NextArrow />}
           prevArrow={<PrevArrow />}
           slideWidth="1200px"


### PR DESCRIPTION
disable dragging of the slide to prevent bug where link gets activated on drag
dragging still works on mobile