### PR TITLE
Renamed the German Translation of the Slider Block from "Schieberegler" into "Slider"

### DIFF
--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -55,7 +55,7 @@ msgstr "Bitte wählen sie einen existierenden Inhalt als Quelle für dieses Elem
 #: components/schema
 # defaultMessage: Slider
 msgid "Slider"
-msgstr "Schieberegler"
+msgstr "Slider"
 
 #: components/DefaultBody
 #: components/schema


### PR DESCRIPTION
"Schieberegler" is very misleading