### PR TITLE
add conditionals to hide arrow and dot buttons if only one slide

### DIFF
--- a/news/40.feature
+++ b/news/40.feature
@@ -1,1 +1,1 @@
-Add `single-slide` classname to improve styling @danalvrz
+Add conditionals around arrow and dot buttons, and hide them, if there is only one slide @danalvrz

--- a/news/40.feature
+++ b/news/40.feature
@@ -1,0 +1,1 @@
+Add `single-slide` classname to improve styling @danalvrz

--- a/src/components/View.jsx
+++ b/src/components/View.jsx
@@ -96,7 +96,9 @@ const SliderView = (props) => {
   return (
     <>
       <div
-        className={cx('block slider', className)}
+        className={cx('block slider', className, {
+          'single-slide': data.slides?.length === 1,
+        })}
         style={{ '--slider-container-width': `${sliderContainerWidth}px` }}
       >
         {(data.slides?.length === 0 || !data.slides) && isEditMode && (

--- a/src/components/View.jsx
+++ b/src/components/View.jsx
@@ -142,18 +142,19 @@ const SliderView = (props) => {
               </div>
             </div>
             {data.slides?.length > 1 && (
-            <div className="slider-dots">
-              {scrollSnaps.map((_, index) => (
-                <DotButton
-                  key={index}
-                  index={index}
-                  onClick={() => scrollTo(index)}
-                  className={'slider-dot'.concat(
-                    index === selectedIndex ? ' slider-dot--selected' : '',
-                  )}
-                />
-              ))}
-            </div>)}
+              <div className="slider-dots">
+                {scrollSnaps.map((_, index) => (
+                  <DotButton
+                    key={index}
+                    index={index}
+                    onClick={() => scrollTo(index)}
+                    className={'slider-dot'.concat(
+                      index === selectedIndex ? ' slider-dot--selected' : '',
+                    )}
+                  />
+                ))}
+              </div>
+            )}
           </>
         )}
       </div>

--- a/src/components/View.jsx
+++ b/src/components/View.jsx
@@ -96,9 +96,7 @@ const SliderView = (props) => {
   return (
     <>
       <div
-        className={cx('block slider', className, {
-          'single-slide': data.slides?.length === 1,
-        })}
+        className={cx('block slider', className)}
         style={{ '--slider-container-width': `${sliderContainerWidth}px` }}
       >
         {(data.slides?.length === 0 || !data.slides) && isEditMode && (
@@ -112,7 +110,7 @@ const SliderView = (props) => {
         {data.slides?.length > 0 && (
           <>
             <div className="slider-wrapper">
-              {!data.hideArrows && (
+              {!data.hideArrows && data.slides?.length > 1 && (
                 <>
                   <PrevButton onClick={scrollPrev} disabled={prevBtnDisabled} />
                   <NextButton onClick={scrollNext} disabled={nextBtnDisabled} />
@@ -143,7 +141,7 @@ const SliderView = (props) => {
                 </div>
               </div>
             </div>
-
+            {data.slides?.length > 1 && (
             <div className="slider-dots">
               {scrollSnaps.map((_, index) => (
                 <DotButton
@@ -155,7 +153,7 @@ const SliderView = (props) => {
                   )}
                 />
               ))}
-            </div>
+            </div>)}
           </>
         )}
       </div>


### PR DESCRIPTION
To have a trigger for styling single-slide Slider blocks (ex. hide `.slider-dots`) 